### PR TITLE
Fix extract filter column target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.5.2 (webpack)
+* extractFilterColumnTarget method was corrected to extract table and column name from correct properties for *non* hierarchical data
+
 ## 5.5.1 (webpack)
 * extractFilterColumnTarget method was corrected to extract table and column name from correct properties for hierarchical data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-interactivityutils",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-interactivityutils",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "InteractivityUtils",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/interactivityFilterService.ts
+++ b/src/interactivityFilterService.ts
@@ -84,7 +84,7 @@ export function extractFilterColumnTarget(categoryColumn: powerbi.DataViewCatego
                 filterTargetTable = (columnMeta.identityExprs as any).source.entity;
             }
         } else if (expr.kind === SQExprKind.ColumnRef) {
-            filterTargetTable = (columnMeta.identityExprs[0] as any).source.entity;
+            filterTargetTable = expr.source.entity;
             filterTargetColumn = expr.ref;
         }
     }

--- a/src/interactivityFilterService.ts
+++ b/src/interactivityFilterService.ts
@@ -83,6 +83,9 @@ export function extractFilterColumnTarget(categoryColumn: powerbi.DataViewCatego
             } else {
                 filterTargetTable = (columnMeta.identityExprs as any).source.entity;
             }
+        } else if (expr.kind === SQExprKind.ColumnRef) {
+            filterTargetTable = (columnMeta.identityExprs[0] as any).source.entity;
+            filterTargetColumn = expr.ref;
         }
     }
 

--- a/test/interactivityServiceTest.ts
+++ b/test/interactivityServiceTest.ts
@@ -157,7 +157,7 @@ describe("Interactivity service", () => {
             expect(filetColumnTarget.column).toBeNull();
         });
 
-        it("Extract Filter Column Target for hierarchical data", () => {
+        it("Extract Filter Column Target for hierarchical data (dataViewMappings: table, source: Multidimensional)", () => {
             let regularCategoryColumn: any = {
                 "roles": {
                     "Fields": true
@@ -203,6 +203,124 @@ describe("Interactivity service", () => {
             let filetColumnTarget: IFilterColumnTarget = extractFilterColumnTarget(regularCategoryColumn);
             expect(filetColumnTarget.table).toBe("Organization");
             expect(filetColumnTarget.column).toBe("Organization Level 02");
+        });
+
+        it("Extract Filter Column Target for hierarchical data (dataViewMappings: table, source: import mode)", () => {
+            let regularCategoryColumn: any = {
+                roles: {
+                    Fields: true
+                },
+                type: {
+                    text: true
+                },
+                displayName: "Country Name",
+                queryName: "Sales.Channel Partner Hierarchy.Country",
+                expr: {
+                    arg: {
+                        arg: {
+                            entity: "Sales",
+                            variable: "f",
+                            kind: 0
+                        },
+                        hierarchy: "Channel Partner Hierarchy",
+                        kind: 6
+                    },
+                    level: "Country",
+                    kind: 7
+                },
+                index: 1,
+                identityExprs: [
+                    {
+                        source: {
+                            entity: "Sales",
+                            kind: 0
+                        },
+                        ref: "Country",
+                        kind: 2
+                    }
+                ]
+            };
+            let filetColumnTarget: IFilterColumnTarget = extractFilterColumnTarget(regularCategoryColumn);
+            expect(filetColumnTarget.table).toBe("Sales");
+            expect(filetColumnTarget.column).toBe("Country");
+        });
+
+        it("Extract Filter Column Target for datetime column with 'auto date/time' set to on (dataViewMappings: table, source: import mode)", () => {
+            let regularCategoryColumn: any = {
+                roles: {
+                    Fields: true
+                },
+                type: {
+                    text: true
+                },
+                displayName: "Year",
+                queryName: "Sales.Date.Variation.Date Hierarchy.Year",
+                expr: {
+                    arg: {
+                        arg: {
+                            arg: {
+                                entity: "Sales",
+                                variable: "f",
+                                kind: 0
+                            },
+                            name: "Variation",
+                            property: "Date",
+                            kind: 5
+                        },
+                        hierarchy: "Date Hierarchy",
+                        kind: 6
+                    },
+                    level: "Year",
+                    kind: 7
+                },
+                index: 0,
+                identityExprs: [
+                    {
+                        source: {
+                            entity: "LocalDateTable_bcfa94c1-7c12-4317-9a5f-204f8a9724ca",
+                            kind: 0
+                        },
+                        ref: "Year",
+                        kind: 2
+                    }
+                ]
+            };
+            let filetColumnTarget: IFilterColumnTarget = extractFilterColumnTarget(regularCategoryColumn);
+            expect(filetColumnTarget.table).toBe("LocalDateTable_bcfa94c1-7c12-4317-9a5f-204f8a9724ca");
+            expect(filetColumnTarget.column).toBe("Year");
+        });
+
+        it("Extract Filter Column Target for single column (dataViewMappings: table, source: import mode)", () => {
+            let regularCategoryColumn: any = {
+                roles: {
+                    Fields: true
+                },
+                type: {
+                    text: true
+                },
+                displayName: "Organization Level 01",
+                queryName: "Organization.Organization Level 01",
+                expr: {
+                    source: {
+                        entity: "Organization"
+                    },
+                    ref: "Organization Level 01",
+                    kind: 2
+                },
+                index: 1,
+                identityExprs: [
+                    {
+                        source: {
+                            entity: "Organization"
+                        },
+                        ref: "Organization Level 01",
+                        kind: 2
+                    }
+                ]
+            };
+            let filetColumnTarget: IFilterColumnTarget = extractFilterColumnTarget(regularCategoryColumn);
+            expect(filetColumnTarget.table).toBe("Organization");
+            expect(filetColumnTarget.column).toBe("Organization Level 01");
         });
     });
 


### PR DESCRIPTION
## Problem

Using the `extractFilterColumnTarget` with * non* hierarchical data resulted in
```
{
    table: null,
    column: null
}
```

## Solution

- Added extra check `expr.kind === SQExprKind.ColumnRef` to parse table *non* hierarchical data correctly.
- Added extra test for `extractFilterColumnTarget` to test *non* hierarchical data scenarios